### PR TITLE
Improve the mobile experience by making the layout more compact

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -355,6 +355,15 @@ const topVisibility: JupyterFrontEndPlugin<void> = {
     if (menu) {
       menu.viewMenu.addGroup([{ command: CommandIDs.toggleTop }], 2);
     }
+
+    // listen on format change (mobile and desktop) to make the view more compact
+    app.formatChanged.connect(() => {
+      if (app.format === 'desktop') {
+        classicShell.expandTop();
+      } else {
+        classicShell.collapseTop();
+      }
+    });
   },
   autoStart: true
 };

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -396,18 +396,16 @@ const zen: JupyterFrontEndPlugin<void> = {
   ): void => {
     const { commands } = app;
     const elem = document.documentElement;
-    const topArea = classicShell?.top;
-    const menuArea = classicShell?.menu;
 
     const toggleOn = () => {
-      topArea?.setHidden(true);
-      menuArea?.setHidden(true);
+      classicShell?.collapseTop();
+      classicShell?.menu.setHidden(true);
       zenModeEnabled = true;
     };
 
     const toggleOff = () => {
-      topArea?.setHidden(false);
-      menuArea?.setHidden(false);
+      classicShell?.expandTop();
+      classicShell?.menu.setHidden(false);
       zenModeEnabled = false;
     };
 

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -50,6 +50,7 @@
     "@lumino/algorithm": "^1.3.3",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/messaging": "^1.4.3",
+    "@lumino/polling": "^1.3.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.14.0",
     "es6-promise": "~4.2.8"

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -63,16 +63,44 @@ export class ClassicShell extends Widget implements JupyterFrontEnd.IShell {
     BoxLayout.setStretch(menuWrapper, 0);
     BoxLayout.setStretch(this._main, 1);
 
-    const spacer = new Widget();
-    spacer.node.style.minHeight = '16px';
+    this._spacer = new Widget();
+    this._spacer.id = 'spacer-widget';
 
     rootLayout.spacing = 0;
     rootLayout.addWidget(topWrapper);
     rootLayout.addWidget(menuWrapper);
-    rootLayout.addWidget(spacer);
+    rootLayout.addWidget(this._spacer);
     rootLayout.addWidget(this._main);
 
     this.layout = rootLayout;
+  }
+
+  /**
+   * A signal emitted when the current widget changes.
+   */
+  get currentChanged(): ISignal<ClassicShell, void> {
+    return this._currentChanged;
+  }
+
+  /**
+   * The current widget in the shell's main area.
+   */
+  get currentWidget(): Widget {
+    return this._main.widgets[0];
+  }
+
+  /**
+   * Get the top area wrapper panel
+   */
+  get top(): Widget {
+    return this._topWrapper;
+  }
+
+  /**
+   * Get the menu area wrapper panel
+   */
+  get menu(): Widget {
+    return this._menuWrapper;
   }
 
   activateById(id: string): void {
@@ -114,31 +142,19 @@ export class ClassicShell extends Widget implements JupyterFrontEnd.IShell {
   }
 
   /**
-   * A signal emitted when the current widget changes.
+   * Collapse the top area and the spacer to make the view more compact.
    */
-  get currentChanged(): ISignal<ClassicShell, void> {
-    return this._currentChanged;
+  collapseTop(): void {
+    this._topWrapper.setHidden(true);
+    this._spacer.setHidden(true);
   }
 
   /**
-   * The current widget in the shell's main area.
+   * Expand the top area to show the header and the spacer.
    */
-  get currentWidget(): Widget {
-    return this._main.widgets[0];
-  }
-
-  /**
-   * Get the top area wrapper panel
-   */
-  get top(): Widget {
-    return this._topWrapper;
-  }
-
-  /**
-   * Get the menu area wrapper panel
-   */
-  get menu(): Widget {
-    return this._menuWrapper;
+  expandTop(): void {
+    this._topWrapper.setHidden(false);
+    this._spacer.setHidden(false);
   }
 
   /**
@@ -160,6 +176,7 @@ export class ClassicShell extends Widget implements JupyterFrontEnd.IShell {
   private _topHandler: Private.PanelHandler;
   private _menuWrapper: Panel;
   private _menuHandler: Private.PanelHandler;
+  private _spacer: Widget;
   private _main: Panel;
   private _currentChanged = new Signal<this, void>(this);
 }

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -63,3 +63,7 @@ body {
   margin-right: auto;
   max-width: 1200px;
 }
+
+#spacer-widget {
+  min-height: 16px;
+}


### PR DESCRIPTION
Follow-up to #32 

- The header can still be enabled via the menu
- Make the zen mode even more compact

![mobile-compact-view](https://user-images.githubusercontent.com/591645/101923646-f800c080-3bcf-11eb-9b7d-66c9efa3f293.gif)

![compact-zen-mode](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)

