### PR TITLE
Show notebook toolbar button only in LabShell

### DIFF
--- a/packages/lab-extension/src/index.ts
+++ b/packages/lab-extension/src/index.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  ILabShell,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
@@ -73,15 +74,17 @@ class ClassicButton
 const openClassic: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab-classic/lab-extension:open-classic',
   autoStart: true,
-  optional: [INotebookTracker, ICommandPalette, IMainMenu],
+  optional: [INotebookTracker, ICommandPalette, IMainMenu, ILabShell],
   activate: (
     app: JupyterFrontEnd,
     notebookTracker: INotebookTracker | null,
     palette: ICommandPalette | null,
-    menu: IMainMenu | null
+    menu: IMainMenu | null,
+    labShell: ILabShell | null
   ) => {
     // TODO: do not activate if already in a IClassicShell?
-    if (!notebookTracker) {
+    if (!notebookTracker || !labShell) {
+      // to prevent showing the toolbar button in JupyterLab Classic
       return;
     }
 


### PR DESCRIPTION
It was a bit off that the toolbar button would be shown when already in Classic.

So now it is only displayed in JupyterLab:

![image](https://user-images.githubusercontent.com/591645/101925335-08b23600-3bd2-11eb-8e9d-28258ba6fe32.png)


![image](https://user-images.githubusercontent.com/591645/101925357-0ea81700-3bd2-11eb-93af-68014b9eef61.png)
