### PR TITLE
Add file browser buttons to create new notebooks, files and terminals

### DIFF
--- a/builder/index.js
+++ b/builder/index.js
@@ -111,12 +111,7 @@ async function main() {
   const page = PageConfig.getOption('classicPage');
   if (page === 'tree') {
     mods = mods.concat([
-      require('@jupyterlab-classic/tree-extension').default.filter(({ id }) =>
-        [
-          '@jupyterlab-classic/tree-extension:browser',
-          '@jupyterlab-classic/tree-extension:factory'
-        ].includes(id)
-      ),
+      require('@jupyterlab-classic/tree-extension'),
       require('@jupyterlab/running-extension')
     ]);
   } else if (page === 'notebooks') {

--- a/packages/tree-extension/style/base.css
+++ b/packages/tree-extension/style/base.css
@@ -22,3 +22,23 @@
   padding-left: 5px;
   padding-right: 5px;
 }
+
+/* Override the style from upstream JupyterLab */
+.jp-FileBrowser-toolbar.jp-Toolbar
+  .jp-Toolbar-item:first-child
+  .jp-ToolbarButtonComponent {
+  width: auto;
+  background: unset;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar
+  .jp-Toolbar-item:first-child
+  .jp-ToolbarButtonComponent:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar .jp-ToolbarButtonComponent {
+  width: unset;
+}


### PR DESCRIPTION
Fixes #42 

![new-notebook-file-terminal](https://user-images.githubusercontent.com/591645/101937650-6f3f5000-3be2-11eb-8cf4-0eebc917ef4c.gif)
