### PR TITLE
Tweak Tree TabBar padding

### DIFF
--- a/packages/tree-extension/style/base.css
+++ b/packages/tree-extension/style/base.css
@@ -9,13 +9,13 @@
 .jp-TreePanel .lm-TabPanel-tabBar {
   border: none;
   overflow: visible;
-  min-height: 28px;
+  min-height: 32px;
 }
 
 .jp-TreePanel .lm-TabBar-tab {
   color: var(--jp-ui-font-color0);
   font-size: var(--jp-ui-font-size1);
-  padding: 5px;
+  padding: 8px;
 }
 
 .jp-TreePanel .lm-TabBar-tabLabel {


### PR DESCRIPTION
Small tweak to the padding which might look a bit bit better.

### Before

![image](https://user-images.githubusercontent.com/591645/101940340-a1eb4780-3be6-11eb-94b8-4a925ac89295.png)

### After

![image](https://user-images.githubusercontent.com/591645/101940229-76685d00-3be6-11eb-8898-6451f1b3dd7c.png)
