### PR TITLE
Use skip_if_exists from jupyter-packaging

### DIFF
--- a/jupyterlab_classic/app.py
+++ b/jupyterlab_classic/app.py
@@ -103,6 +103,7 @@ class ClassicNotebookHandler(ClassicHandler):
 class ClassicApp(NBClassicConfigShimMixin, LabServerApp):
     name = "classic"
     app_name = "JupyterLab Classic"
+    description = "JupyterLab Classic - A JupyterLab Distribution with the Classic Notebook look and feel"
     app_version = version
     extension_url = "/classic/tree"
     load_other_extensions = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.0", "jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.7.9", "jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from jupyter_packaging import (
     combine_commands,
     install_npm,
     ensure_targets,
+    skip_if_exists,
 )
 import setuptools
 
@@ -30,7 +31,6 @@ lab_extension_source = os.path.join(HERE, "packages", "lab-extension")
 
 # Representative files that should exist after a successful build
 jstargets = [
-    os.path.join(lab_extension_source, "lib", "index.js"),
     os.path.join(lab_extension_dest, "package.json"),
     os.path.join(main_bundle_dest, "bundle.js"),
 ]
@@ -56,12 +56,19 @@ cmdclass = create_cmdclass(
     "jsdeps", package_data_spec=package_data_spec, data_files_spec=data_files_spec
 )
 
-cmdclass["jsdeps"] = combine_commands(
+js_command = combine_commands(
     install_npm(HERE, build_cmd="install", npm=["jlpm"]),
     install_npm(HERE, build_cmd="build", npm=["jlpm"]),
     install_npm(main_bundle_source, build_cmd="build:prod", npm=["jlpm"]),
     ensure_targets(jstargets),
 )
+
+is_repo = os.path.exists(os.path.join(HERE, ".git"))
+if is_repo:
+    cmdclass["jsdeps"] = js_command
+else:
+    cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ jstargets = [
     os.path.join(main_bundle_dest, "bundle.js"),
 ]
 
-package_data_spec = {PACKAGE_NAME: ["*"]}
+package_data_spec = {PACKAGE_NAME: ["*", "templates/*", "static/**"]}
 
 data_files_spec = [
     ("share/jupyter/labextensions/%s" % labext_name, lab_extension_dest, "**"),
@@ -81,7 +81,7 @@ setup_args = dict(
     description="The next gen old-school Notebook UI",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    cmdclass= cmdclass,
+    cmdclass=cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
         "jupyterlab~=3.0",
@@ -102,9 +102,7 @@ setup_args = dict(
         "Programming Language :: Python :: 3.9",
         "Framework :: Jupyter",
     ],
-    entry_points={
-        "console_scripts": ["jupyter-classic = jupyterlab_classic.app:main"]
-    },
+    entry_points={"console_scripts": ["jupyter-classic = jupyterlab_classic.app:main"]},
 )
 
 


### PR DESCRIPTION
To not rebuild the js assets if they are already bundled.

To make packaging on conda easier for example.