### PR TITLE
consume readme with utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,8 @@ else:
     cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
 
 
-with open("README.md", "r") as fh:
-    long_description = fh.read(encoding="utf-8")
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
 
 setup_args = dict(
     name=NAME,

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ else:
 
 
 with open("README.md", "r") as fh:
-    long_description = fh.read()
+    long_description = fh.read(encoding="utf-8")
 
 setup_args = dict(
     name=NAME,


### PR DESCRIPTION
This ensures the `README.md` gets read properly as unicode on windows.

Another approach would be to hoist it to `setup.cfg` or `pyproject.toml` which already take care of _some_ of these concerns.

- unblocks https://github.com/conda-forge/staged-recipes/pull/13552#pullrequestreview-560595550