### PR TITLE
[wip] include npm tarballs in dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,12 +66,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel
         python -m pip install setuptools jupyter_packaging "jupyterlab>=3,<4"
-    - name: Build packages
+    - name: Build pypi distributions
       run: |
         python setup.py sdist bdist_wheel
+    - name: Build npm distributions
+      run: |
+        jlpm lerna exec -- npm pack
+        cp packages/*/*.tgz dist
+    - name: Build checksum file
+      run: |
         cd dist
         sha256sum * | tee SHA256SUMS
-    - name: Upload builds
+    - name: Upload distributions
       uses: actions/upload-artifact@v2
       with:
         name: dist ${{ github.run_number }}


### PR DESCRIPTION
Hooray continuing to publish on npm and not build another walled garden!

This builds and includes the `npm` tarballs in the `dist` artifact... these can be directly uploaded with `(npm|lerna) publish` (or whatever, i always forget), and has the advantage of what is published being _exactly_ what was tested, instead of whatever happens to be on a developer's box at the time. I've learned this the hard way a few times :blush: .

- follow-on to https://github.com/jtpio/jupyterlab-classic/pull/68#issuecomment-755224375