### PR TITLE
Add mamba / conda install and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![Github Actions Status](https://github.com/jtpio/jupyterlab-classic/workflows/Build/badge.svg)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/jupyterlab-classic/main?urlpath=classic/notebooks/binder/example.ipynb)
+[![PyPI](https://img.shields.io/pypi/v/jupyterlab-classic.svg)](https://pypi.org/project/jupyterlab-classic)
+[![conda-forge](https://img.shields.io/conda/vn/conda-forge/jupyterlab-classic.svg)](https://anaconda.org/conda-forge/jupyterlab-classic)
 
 The next gen old-school Notebook UI.
 
@@ -15,7 +17,13 @@ The next gen old-school Notebook UI.
 pip install jupyterlab-classic
 ```
 
-And with `conda` (coming soon):
+With `mamba`:
+
+```bash
+mamba install -c conda-forge jupyterlab-classic
+```
+
+With `conda`:
 
 ```bash
 conda install -c conda-forge jupyterlab-classic

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,18 @@ Make sure the `dist/` folder is empty.
 5. `export TWINE_USERNAME=mypypi_username`
 6. `twine upload dist/*`
 
+## Releasing on conda-forge
+
+The simplest is to wait for the bot to automatically open the PR.
+
+Alternatively, to do the update manually:
+
+1. Open a new PR on https://github.com/conda-forge/jupyterlab-classic-feedstock to update the `version` and the `sha256` hash
+2. Wait for the tests
+3. Merge the PR
+
+The new version will be available on `conda-forge` soon after.
+
 ## Publish the packages to npm
 
 1. Bump the version in


### PR DESCRIPTION
Now that `jupyterlab-classic` is also available on conda-forge.

```bash
mamba install -c conda-forge jupyterlab-classic
```