### PR TITLE
shell.widgets() throws if the area is invalid

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -169,13 +169,16 @@ export class ClassicShell extends Widget implements JupyterFrontEnd.IShell {
    * @param area The area
    */
   widgets(area: Shell.Area): IIterator<Widget> {
-    if (area === 'top') {
-      return iter(this._topHandler.panel.widgets);
+    switch (area ?? 'main') {
+      case 'top':
+        return iter(this._topHandler.panel.widgets);
+      case 'menu':
+        return iter(this._menuHandler.panel.widgets);
+      case 'main':
+        return iter(this._main.widgets);
+      default:
+        throw new Error(`Invalid area: ${area}`);
     }
-    if (area === 'menu') {
-      return iter(this._menuHandler.panel.widgets);
-    }
-    return iter(this._main.widgets);
   }
 
   private _topWrapper: Panel;

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -3,11 +3,35 @@
 
 import { ClassicShell } from '@jupyterlab-classic/application';
 
+import { JupyterFrontEnd } from '@jupyterlab/application';
+
+import { toArray } from '@lumino/algorithm';
+
+import { Widget } from '@lumino/widgets';
+
 describe('Shell', () => {
   describe('#constructor()', () => {
     it('should create a LabShell instance', () => {
       const shell = new ClassicShell();
       expect(shell).toBeInstanceOf(ClassicShell);
+    });
+  });
+
+  describe('#widgets()', () => {
+    it('should add widgets to existing areas', () => {
+      const shell = new ClassicShell();
+      const widget = new Widget();
+      shell.add(widget, 'main');
+      const widgets = toArray(shell.widgets('main'));
+      expect(widgets).toEqual([widget]);
+    });
+
+    it('should throw an exception if the area does not exist', () => {
+      const classicShell = new ClassicShell();
+      const shell = classicShell as JupyterFrontEnd.IShell;
+      expect(() => {
+        shell.widgets('left');
+      }).toThrow('Invalid area: left');
     });
   });
 });


### PR DESCRIPTION
Instead of silently returning the widgets for the `main` area.

This helps extension better handle different types of shells.