### PR TITLE
Add the codemirror singleton plugin

### DIFF
--- a/builder/index.js
+++ b/builder/index.js
@@ -88,7 +88,10 @@ async function main() {
       ].includes(id)
     ),
     require('@jupyterlab/codemirror-extension').default.filter(({ id }) =>
-      ['@jupyterlab/codemirror-extension:services'].includes(id)
+      [
+        '@jupyterlab/codemirror-extension:services',
+        '@jupyterlab/codemirror-extension:codemirror'
+      ].includes(id)
     ),
     require('@jupyterlab/completer-extension').default.filter(({ id }) =>
       ['@jupyterlab/completer-extension:manager'].includes(id)


### PR DESCRIPTION
This should fix #77 

Add the `@jupyterlab/codemirror-extension:codemirror` plugin by default.