### PR TITLE
Remove skip_existing from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,6 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-        skip_existing: true
     - name: Install Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Which was added in 478fd70b7d9a8813900e43a181dfd7e4e675855a to debug issues when publishing to the npm registry.