### PR TITLE
Set the notebook name in the browser tab title

### DIFF
--- a/jupyterlab_classic/app.py
+++ b/jupyterlab_classic/app.py
@@ -106,6 +106,7 @@ class ClassicApp(NBClassicConfigShimMixin, LabServerApp):
     description = "JupyterLab Classic - A JupyterLab Distribution with the Classic Notebook look and feel"
     app_version = version
     extension_url = "/classic/tree"
+    default_url = "/classic/tree"
     load_other_extensions = True
     app_dir = app_dir
     app_settings_dir = pjoin(app_dir, "settings")

--- a/jupyterlab_classic/templates/edit.html
+++ b/jupyterlab_classic/templates/edit.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{page_config['appName'] | e}} - Edit</title>
+  {% block favicon %}
+  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon-file.ico" class="favicon">
+  {% endblock %}
 </head>
 <body>
 

--- a/jupyterlab_classic/templates/notebooks.html
+++ b/jupyterlab_classic/templates/notebooks.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{page_config['appName'] | e}} - Notebook</title>
+  {% block favicon %}
+  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon-notebook.ico" class="favicon">
+  {% endblock %}
 </head>
 <body>
 

--- a/jupyterlab_classic/templates/terminals.html
+++ b/jupyterlab_classic/templates/terminals.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{page_config['appName'] | e}} - Terminal</title>
+  {% block favicon %}
+  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon-terminal.ico" class="favicon">
+  {% endblock %}
 </head>
 <body>
 

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -285,6 +285,32 @@ const spacer: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin to display the document title in the browser tab title
+ */
+const tabTitle: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab-classic/application-extension:tab-title',
+  autoStart: true,
+  requires: [IClassicShell],
+  activate: (app: JupyterFrontEnd, shell: IClassicShell) => {
+    const setTabTitle = () => {
+      const current = shell.currentWidget;
+      if (!(current instanceof DocumentWidget)) {
+        return;
+      }
+      const update = () => {
+        const basename = PathExt.basename(current.context.path);
+        document.title = basename;
+      };
+      current.context.pathChanged.connect(update);
+      update();
+    };
+
+    shell.currentChanged.connect(setTabTitle);
+    setTabTitle();
+  }
+};
+
+/**
  * A plugin to display and rename the title of a file
  */
 const title: JupyterFrontEndPlugin<void> = {
@@ -472,6 +498,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   sessionDialogs,
   shell,
   spacer,
+  tabTitle,
   title,
   topVisibility,
   translator,


### PR DESCRIPTION
Fixes #99 

https://user-images.githubusercontent.com/591645/106870931-fa643000-66d1-11eb-8d69-6608fdacf6fe.mp4

Also add favicons for notebooks, files and terminals:

![image](https://user-images.githubusercontent.com/591645/106917095-3619ec80-6708-11eb-88cd-f467870be385.png)


cc @chmp for review if you want to try out this change on Binder:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/jupyterlab-classic/notebook-title?urlpath=classic/tree)