### PR TITLE
Change back signature of shell.currentWidget

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -85,8 +85,8 @@ export class ClassicShell extends Widget implements JupyterFrontEnd.IShell {
   /**
    * The current widget in the shell's main area.
    */
-  get currentWidget(): Widget | null {
-    return this._main.widgets[0] ?? null;
+  get currentWidget(): Widget {
+    return this._main.widgets[0];
   }
 
   /**

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -45,15 +45,15 @@ describe('Shell', () => {
 
   describe('#currentWidget', () => {
     it('should be the current widget in the shell main area', () => {
-      expect(shell.currentWidget).toBe(null);
+      expect(shell.currentWidget).toBe(undefined);
       const widget = new Widget();
       widget.node.tabIndex = -1;
       widget.id = 'foo';
-      expect(shell.currentWidget).toBe(null);
+      expect(shell.currentWidget).toBe(undefined);
       shell.add(widget, 'main');
       expect(shell.currentWidget).toBe(widget);
       widget.parent = null;
-      expect(shell.currentWidget).toBe(null);
+      expect(shell.currentWidget).toBe(undefined);
     });
   });
 


### PR DESCRIPTION
Revert one change from https://github.com/jtpio/jupyterlab-classic/pull/95 so it doesn't change the signature of the `shell.currentWidget` method, which could be breaking if consumers are using strict null checks.

We can add it back for `0.2.0`.