### PR TITLE
Fixed the App instantiation options

### DIFF
--- a/packages/application/src/app.ts
+++ b/packages/application/src/app.ts
@@ -23,7 +23,8 @@ export class App extends JupyterFrontEnd<IClassicShell> {
    */
   constructor(options: App.IOptions = { shell: new ClassicShell() }) {
     super({
-      shell: options.shell
+      ...options,
+      shell: options.shell ?? new ClassicShell()
     });
     void this._formatter.invoke();
   }


### PR DESCRIPTION
Noticed when trying to instantiate an `App` with a different `serviceManager`, which would not be taken into account.